### PR TITLE
Article-groups now appear under a navbar menu

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -29,7 +29,27 @@ navbar:
       href: reference/index.html
     articles:
       text: Articles
-      href: articles/index.html
+      menu:
+      - text: "Introduction"
+      - text: "-------"
+      - text: "Introduction"
+        href: articles/introduction.html
+      - text: "Design"
+        href: articles/design.html
+      - text: "Core concepts"
+      - text: "-------"
+      - text: "Defined"
+        href: articles/defined.html
+      - text: "Dataset_df"
+        href: articles/dataset_df.html
+      - text: "Metadata & citation"
+      - text: "-------"
+      - text: "Bibrecord"
+        href: articles/bibrecord.html
+      - text: "Dataset exchanges"
+      - text: "-------"
+      - text: "RDF"
+        href: articles/rdf.html
     github:
       icon: fab fa-github
       href: https://github.com/dataobservatory-eu/dataset/


### PR DESCRIPTION
- Relates to https://github.com/ropensci/software-review/issues/681

----

This is an optional suggestion, mostly to show in code what I meant in words. But what I see now seems great so feel free to close.

Thanks!

### Example

<img width="1505" height="893" alt="Image" src="https://github.com/user-attachments/assets/2e4c85b9-1df4-4f20-90eb-affc391f2499"
